### PR TITLE
Fix broken link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/wwrri8srggv1h56j/branch/main?svg=true)](https://ci.appveyor.com/project/SimonCropp/Verify-NServiceBus)
 [![NuGet Status](https://img.shields.io/nuget/v/Verify.NServiceBus.svg)](https://www.nuget.org/packages/Verify.NServiceBus/)
 
-Adds [Verify](https://github.com/VerifyTests/Verify) support to verify [NServiceBus Test Contexts](https://docs.particular.net/nservicebus/samples/unit-testing/).
+Adds [Verify](https://github.com/VerifyTests/Verify) support to verify [NServiceBus Test Contexts](https://docs.particular.net/nservicebus/testing/).
 
 **See [Milestones](../../milestones?state=closed) for release notes.**
 


### PR DESCRIPTION
Link to docs page for NserviceBus.Testing

Would we prefer updating the link to point to the sample as it was before? This is the updated link for that page:
https://docs.particular.net/samples/unit-testing/